### PR TITLE
Replace deprecated ::set-env workflow command for security reasons

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -11,7 +11,7 @@ jobs:
     - name: environment
       run: |
         export VERSION=$(git rev-parse --short ${GITHUB_SHA})
-        echo "::set-env name=VERSION::${VERSION}"
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
     - name: docker build
       run: |
         docker build \


### PR DESCRIPTION
* replaced unsecure stdout based ::set-env workflow command with save file system based version
* change allows this workflow to run after upcoming deprecation of stdout based command this month (November 2020)

### Sources: 
* [Google Project Zero vulnerability report](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w)
 * [GitHub ::set-env deprecation notes](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
* [migration advice followed in this PR](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)
