### PR TITLE
adding device name field

### DIFF
--- a/src/themes/quick-test/login/login-config-totp.ftl
+++ b/src/themes/quick-test/login/login-config-totp.ftl
@@ -32,7 +32,8 @@
   <input class="input" style="top: 575px;" type="text" placeholder="Einmal-Passwort" name="totp" autocomplete="off"
          required>
   <input type="hidden" name="totpSecret" value="${totp.totpSecret}"/>
-  <input class="button" style="top: 635px;" type="submit" value="Abschicken">
+  <input class="input" style="top: 635px;" type="text" placeholder="OTP Gerät" value="${totp.userLabel}" name="userLabel" autocomplete="off" required/>
+  <input class="button" style="top: 695px;" type="submit" value="Abschicken">
 </form>
 <#if message?? && message.type = 'error'>
   <div class="error" style="top: 695px;">Das von Ihnen eingegebene Einmal-Passwort ist nicht korrekt.<br>Bitte korrigieren Sie Ihre Eingabe.</div>


### PR DESCRIPTION
Due to a missing Device Name field user can not reset OTP codes (after the first reset there has to be a device name set) so trying to add the field in the custom theme.