### PR TITLE
Downgrade Keycloak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:16.1.1
+FROM quay.io/keycloak/keycloak:15.1.0
 
 ARG WORK_DIR=/build
 WORKDIR ${WORK_DIR}

--- a/Dockerfile-QT
+++ b/Dockerfile-QT
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:16.1.1
+FROM quay.io/keycloak/keycloak:15.1.0
 
 ARG WORK_DIR=/build
 WORKDIR ${WORK_DIR}


### PR DESCRIPTION
Downgrade Keycloak to 15.1. because of Support for Security-Realms